### PR TITLE
Implement rate as counter

### DIFF
--- a/pkg/opentelemetry/output.go
+++ b/pkg/opentelemetry/output.go
@@ -181,9 +181,15 @@ func (o *Output) dispatch(entry metrics.Sample) error {
 		}
 
 		trend.Record(ctx, entry.Value, otelMetric.WithAttributes(MapTagSet(entry.Tags)...))
+	case metrics.Rate:
+		rate, err := o.getOrCreateCounter(name)
+		if err != nil {
+			return err
+		}
+
+		rate.Add(ctx, entry.Value, otelMetric.WithAttributes(MapTagSet(entry.Tags)...))
 	default:
-		// TODO: add support for other metric types
-		o.logger.Debugf("Drop unsupported metric type: %s", entry.Metric.Name)
+		o.logger.Warnf("metric %q has unsupported metric type", entry.Metric.Name)
 	}
 
 	return nil


### PR DESCRIPTION
# What?

For the beginning, we do try to treat the `rate` metric as the simple counter, precisely like [we do in `statsd` output](https://github.com/grafana/k6/blob/master/output/statsd/output.go#L68).

# Why?

Rate is one of the metrics types of the k6, and it should work.