### PR TITLE
Adjust mapping of the k6's metrics to the OTEL metrics

### DIFF
--- a/grafana/dashboards/k6-prometheus.json
+++ b/grafana/dashboards/k6-prometheus.json
@@ -182,7 +182,7 @@
             "properties": [
               {
                 "id": "unit",
-                "value": "s"
+                "value": "ms"
               },
               {
                 "id": "custom.axisPlacement",
@@ -250,7 +250,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "expr": "sum(irate(k6_http_reqs{testid=~\"$testid\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "http_req_s",
@@ -263,7 +263,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(round(k6_http_req_failed_rate{testid=~\"$testid\"}, 0.1)*100)",
+          "expr": "avg(k6_http_req_failed_occurred{testid=~\"$testid\"}/k6_http_req_failed_total)*100)",
           "hide": true,
           "instant": false,
           "legendFormat": "http_req_failed",
@@ -276,7 +276,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"}[$__rate_interval]))",
+          "expr": "rate(k6_http_reqs{testid=~\"$testid\", expected_response=\"false\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "http_req_s_errors",
@@ -353,7 +353,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\"})",
+          "expr": "sum(k6_http_reqs{testid=~\"$testid\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -417,7 +417,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"})",
+          "expr": "sum(k6_http_reqs{testid=~\"$testid\", expected_response=\"false\"})",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -480,7 +480,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "expr": "sum(rate(k6_http_reqs{testid=~\"$testid\"}[$__rate_interval]))",
           "instant": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -518,7 +518,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": []
       },
@@ -643,7 +643,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(irate(k6_data_sent_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "expr": "avg(rate(k6_data_sent{testid=~\"$testid\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "data_sent",
           "range": true,
@@ -656,7 +656,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "avg(irate(k6_data_received_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "expr": "avg(rate(k6_data_received{testid=~\"$testid\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "data_received",
@@ -719,7 +719,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": [
           {
@@ -852,7 +852,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": [
           {
@@ -1028,7 +1028,7 @@
               }
             ]
           },
-          "unit": "s"
+          "unit": "ms"
         },
         "overrides": [
           {
@@ -1315,7 +1315,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
+          "expr": "sum(rate(k6_http_reqs_total{testid=~\"$testid\"}[$__rate_interval]))",
           "instant": false,
           "legendFormat": "http_req_s",
           "range": true,
@@ -1327,7 +1327,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"false\"}[$__rate_interval]))",
+          "expr": "rate(k6_http_reqs{testid=~\"$testid\", expected_response=\"false\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "http_req_s_errors",
@@ -1340,7 +1340,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum(irate(k6_http_reqs_total{testid=~\"$testid\", expected_response=\"true\"}[$__rate_interval]))",
+          "expr": "rate(k6_http_reqs{testid=~\"$testid\", expected_response=\"true\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
           "legendFormat": "http_req_s_success",
@@ -1747,7 +1747,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "round(k6_checks_rate{testid=~\"$testid\"}, 0.1)",
+          "expr": "k6_checks_occurred{testid=~\"$testid\"} / k6_checks_total{testid=~\"$testid\"}",
           "format": "table",
           "instant": false,
           "legendFormat": "__auto",
@@ -1902,7 +1902,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "avg(round(k6_checks_rate{testid=~\"$testid\"}, 0.1)*100)",
+          "expr": "avg(k6_checks_occurred{testid=~\"$testid\"}/k6_checks_total{testid=~\"$testid\"}*100)",
           "instant": false,
           "legendFormat": "k6_checks_rate",
           "range": true,
@@ -2047,7 +2047,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "k6 Prometheus",
+  "title": "k6 OpenTelemetry Prometheus",
   "uid": "ccbb2351-2ae2-462f-ae0e-f2c893ad1028",
   "version": 2,
   "weekStart": ""

--- a/pkg/opentelemetry/attribute.go
+++ b/pkg/opentelemetry/attribute.go
@@ -6,12 +6,12 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// MapTagSet converts a k6 tag set into
+// newAttributeSet converts a k6 tag set into
 // the equivalent set of opentelemetry attributes
-func MapTagSet(t *metrics.TagSet) []attribute.KeyValue {
+func newAttributeSet(t *metrics.TagSet) attribute.Set {
 	n := (*atlas.Node)(t)
 	if n.Len() < 1 {
-		return nil
+		return *attribute.EmptySet()
 	}
 	labels := make([]attribute.KeyValue, 0, n.Len())
 	for !n.IsRoot() {
@@ -22,5 +22,6 @@ func MapTagSet(t *metrics.TagSet) []attribute.KeyValue {
 		}
 		labels = append(labels, attribute.String(key, value))
 	}
-	return labels
+
+	return attribute.NewSet(labels...)
 }

--- a/pkg/opentelemetry/gauge.go
+++ b/pkg/opentelemetry/gauge.go
@@ -1,0 +1,67 @@
+package opentelemetry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// NewFloat64Gauge returns a new Float64Gauge.
+func NewFloat64Gauge() *Float64Gauge {
+	return &Float64Gauge{}
+}
+
+// Float64Gauge is a temporary implementation of the OpenTelemetry sync gauge
+// it will be replaced by the official implementation once it's available.
+//
+// https://github.com/open-telemetry/opentelemetry-go/issues/3984
+type Float64Gauge struct {
+	observations sync.Map
+}
+
+// Callback implements the callback function for the underlying asynchronous gauge
+// it observes the current state of all previous Set() calls.
+func (f *Float64Gauge) Callback(_ context.Context, o metric.Float64Observer) error {
+	var err error
+
+	f.observations.Range(func(key, value interface{}) bool {
+		var v float64
+
+		// TODO: improve type assertion
+		switch val := value.(type) {
+		case float64:
+			v = val
+		case int64:
+			v = float64(val)
+		default:
+			err = errors.New("unexpected type for value " + fmt.Sprintf("%T", val))
+			return false
+		}
+
+		attrs, ok := key.(attribute.Set)
+		if !ok {
+			err = errors.New("unexpected type for key")
+			return false
+		}
+
+		o.Observe(v, metric.WithAttributeSet(attrs))
+
+		return true
+	})
+
+	return err
+}
+
+// Set sets the value of the gauge.
+func (f *Float64Gauge) Set(val float64, attrs attribute.Set) {
+	f.observations.Store(attrs, val)
+}
+
+// Delete deletes the gauge.
+func (f *Float64Gauge) Delete(attrs attribute.Set) {
+	f.observations.Delete(attrs)
+}

--- a/pkg/opentelemetry/output.go
+++ b/pkg/opentelemetry/output.go
@@ -167,6 +167,16 @@ func (o *Output) dispatch(entry metrics.Sample) error {
 		}
 
 		trend.Record(ctx, entry.Value, otelMetric.WithAttributes(MapTagSet(entry.Tags)...))
+	case metrics.Rate:
+		nonZero, total, err := o.metricsRegistry.getOrCreateCountersForRate(name)
+		if err != nil {
+			return err
+		}
+
+		if entry.Value != 0 {
+			nonZero.Add(ctx, 1, otelMetric.WithAttributes(MapTagSet(entry.Tags)...))
+		}
+		total.Add(ctx, 1, otelMetric.WithAttributes(MapTagSet(entry.Tags)...))
 	default:
 		o.logger.Warnf("metric %q has unsupported metric type", entry.Metric.Name)
 	}

--- a/pkg/opentelemetry/registry.go
+++ b/pkg/opentelemetry/registry.go
@@ -16,6 +16,7 @@ type registry struct {
 	counters       sync.Map
 	upDownCounters sync.Map
 	histograms     sync.Map
+	rateCounters   sync.Map
 }
 
 // newRegistry creates a new registry.
@@ -84,4 +85,52 @@ func (r *registry) getOrCreateUpDownCounter(name string) (otelMetric.Float64UpDo
 
 	r.upDownCounters.Store(name, c)
 	return c, nil
+}
+
+func (r *registry) getOrCreateCountersForRate(name string) (otelMetric.Int64Counter, otelMetric.Int64Counter, error) {
+	// k6's rate metric tracks how frequently a non-zero value occurs.
+	// so to correctly calculate the rate in a metrics backend
+	// we need to split the rate metric into two counters:
+	// 2. number of non-zero occurrences
+	// 1. the total number of occurrences
+
+	nonZeroName := name + ".occurred"
+	totalName := name + ".total"
+
+	var err error
+	var nonZeroCounter, totalCounter otelMetric.Int64Counter
+
+	storedNonZeroCounter, ok := r.rateCounters.Load(nonZeroName)
+	if !ok {
+		nonZeroCounter, err = r.meter.Int64Counter(nonZeroName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create counter for %q: %w", nonZeroName, err)
+		}
+
+		r.rateCounters.Store(nonZeroName, nonZeroCounter)
+		r.logger.Debugf("registered counter metric %q", nonZeroName)
+	} else {
+		nonZeroCounter, ok = storedNonZeroCounter.(otelMetric.Int64Counter)
+		if !ok {
+			return nil, nil, fmt.Errorf("metric %q stored not as counter", nonZeroName)
+		}
+	}
+
+	storedTotalCounter, ok := r.rateCounters.Load(totalName)
+	if !ok {
+		totalCounter, err = r.meter.Int64Counter(totalName)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create counter for %q: %w", totalName, err)
+		}
+
+		r.rateCounters.Store(totalName, totalCounter)
+		r.logger.Debugf("registered counter metric %q", totalName)
+	} else {
+		totalCounter, ok = storedTotalCounter.(otelMetric.Int64Counter)
+		if !ok {
+			return nil, nil, fmt.Errorf("metric %q stored not as counter", totalName)
+		}
+	}
+
+	return nonZeroCounter, totalCounter, nil
 }

--- a/pkg/opentelemetry/registry.go
+++ b/pkg/opentelemetry/registry.go
@@ -1,0 +1,87 @@
+package opentelemetry
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	otelMetric "go.opentelemetry.io/otel/metric"
+)
+
+// registry keep track of all metrics that have been used.
+type registry struct {
+	meter  otelMetric.Meter
+	logger logrus.FieldLogger
+
+	counters       sync.Map
+	upDownCounters sync.Map
+	histograms     sync.Map
+}
+
+// newRegistry creates a new registry.
+func newRegistry(meter otelMetric.Meter, logger logrus.FieldLogger) *registry {
+	return &registry{
+		meter:  meter,
+		logger: logger,
+	}
+}
+
+func (r *registry) getOrCreateCounter(name string) (otelMetric.Float64Counter, error) {
+	if counter, ok := r.counters.Load(name); ok {
+		if v, ok := counter.(otelMetric.Float64Counter); ok {
+			return v, nil
+		}
+
+		return nil, fmt.Errorf("metric %q is not a counter", name)
+	}
+
+	c, err := r.meter.Float64Counter(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create counter for %q: %w", name, err)
+	}
+
+	r.logger.Debugf("registered counter metric %q", name)
+
+	r.counters.Store(name, c)
+	return c, nil
+}
+
+func (r *registry) getOrCreateHistogram(name string) (otelMetric.Float64Histogram, error) {
+	if histogram, ok := r.histograms.Load(name); ok {
+		if v, ok := histogram.(otelMetric.Float64Histogram); ok {
+			return v, nil
+		}
+
+		return nil, fmt.Errorf("metric %q is not a histogram", name)
+	}
+
+	h, err := r.meter.Float64Histogram(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create histogram for %q: %w", name, err)
+	}
+
+	r.logger.Debugf("registered histogram metric %q", name)
+
+	r.histograms.Store(name, h)
+	return h, nil
+}
+
+func (r *registry) getOrCreateUpDownCounter(name string) (otelMetric.Float64UpDownCounter, error) {
+	if counter, ok := r.upDownCounters.Load(name); ok {
+		if v, ok := counter.(otelMetric.Float64UpDownCounter); ok {
+			return v, nil
+		}
+
+		return nil, fmt.Errorf("metric %q is not an up/down counter", name)
+	}
+
+	c, err := r.meter.Float64UpDownCounter(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create up/down counter for %q: %w", name, err)
+	}
+
+	r.logger.Debugf("registered up/down counter (gauge) metric %q ", name)
+
+	r.upDownCounters.Store(name, c)
+	return c, nil
+}


### PR DESCRIPTION
# What?

* It's a minor refactoring of existing logic
* I'm adding rate matric handling as proposed (https://github.com/grafana/xk6-output-opentelemetry/pull/4#discussion_r1623890955). I'm also going to open the ticket and try to gather feedback from the community.
* Switching the gauge to the OTEL Gauge.
* Minor (not final) dashboard adjustments

# Why?

We'd like to export all metrics properly.
