### PR TITLE
Set default export interval as 10s

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It's worth to mention that the extension is using the [OpenTelemetry Go SDK](htt
 
 ### OpenTelemetry-specific configuration
 
-* `K6_OTEL_EXPORT_INTERVAL` - configures the intervening time between metrics exports. Default is `1s`.
+* `K6_OTEL_EXPORT_INTERVAL` - configures the intervening time between metrics exports. Default is `10s`.
 * `K6_OTEL_EXPORTER_TYPE` - metric exporter type. Default is `grpc`.
 
 #### GRPC exporter

--- a/pkg/opentelemetry/config.go
+++ b/pkg/opentelemetry/config.go
@@ -102,7 +102,7 @@ func newDefaultConfig() Config {
 		GRPCExporterInsecure: null.BoolFrom(false),
 		GRPCExporterEndpoint: null.StringFrom("localhost:4317"),
 
-		ExportInterval: types.NullDurationFrom(1 * time.Second),
+		ExportInterval: types.NullDurationFrom(10 * time.Second),
 		FlushInterval:  types.NullDurationFrom(1 * time.Second),
 	}
 }

--- a/pkg/opentelemetry/config_test.go
+++ b/pkg/opentelemetry/config_test.go
@@ -31,7 +31,7 @@ func TestConfig(t *testing.T) {
 				HTTPExporterURLPath:  null.StringFrom("/v1/metrics"),
 				GRPCExporterInsecure: null.NewBool(false, true),
 				GRPCExporterEndpoint: null.StringFrom("localhost:4317"),
-				ExportInterval:       types.NullDurationFrom(1 * time.Second),
+				ExportInterval:       types.NullDurationFrom(10 * time.Second),
 				FlushInterval:        types.NullDurationFrom(1 * time.Second),
 			},
 		},


### PR DESCRIPTION
# What?

Set default export interval as `10s`

# Why?

`1s` sounds too frequent as default value
https://github.com/grafana/k6-docs/pull/1625#discussion_r1644656813