### PR TITLE
Error on scheme in http endpoint

### DIFF
--- a/pkg/opentelemetry/config.go
+++ b/pkg/opentelemetry/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mstoykov/envconfig"
@@ -217,8 +218,14 @@ func (cfg Config) Validate() error {
 	}
 
 	if cfg.ExporterType.String == httpExporterType {
-		if cfg.HTTPExporterEndpoint.String == "" {
+		endpoint := cfg.HTTPExporterEndpoint.String
+		if endpoint == "" {
 			return errors.New("HTTP exporter endpoint is required")
+		}
+
+		if strings.HasPrefix(endpoint, "http://") ||
+			strings.HasPrefix(endpoint, "https://") {
+			return errors.New("HTTP exporter endpoint must only be host and port, no scheme")
 		}
 	}
 

--- a/pkg/opentelemetry/config_test.go
+++ b/pkg/opentelemetry/config_test.go
@@ -129,19 +129,23 @@ func TestConfig(t *testing.T) {
 		},
 
 		"JSON success merge": {
-			jsonRaw: json.RawMessage(`{"exporterType":"http","httpExporterEndpoint":"http://localhost:5566","httpExporterURLPath":"/lorem/ipsum", "exportInterval":"15ms"}`),
+			jsonRaw: json.RawMessage(`{"exporterType":"http","httpExporterEndpoint":"localhost:5566","httpExporterURLPath":"/lorem/ipsum", "exportInterval":"15ms"}`),
 			expectedConfig: Config{
 				ServiceName:          null.StringFrom("k6"),
 				ServiceVersion:       null.StringFrom(k6Const.Version),
 				ExporterType:         null.StringFrom(httpExporterType),
 				HTTPExporterInsecure: null.NewBool(false, true),
-				HTTPExporterEndpoint: null.StringFrom("http://localhost:5566"),
+				HTTPExporterEndpoint: null.StringFrom("localhost:5566"),
 				HTTPExporterURLPath:  null.StringFrom("/lorem/ipsum"),
 				GRPCExporterInsecure: null.NewBool(false, true),         // default
 				GRPCExporterEndpoint: null.StringFrom("localhost:4317"), // default
 				ExportInterval:       types.NullDurationFrom(15 * time.Millisecond),
 				FlushInterval:        types.NullDurationFrom(1 * time.Second),
 			},
+		},
+		"no scheme in http exporter": {
+			jsonRaw: json.RawMessage(`{"exporterType":"http","httpExporterEndpoint":"http://localhost:5566","httpExporterURLPath":"/lorem/ipsum", "exportInterval":"15ms"}`),
+			err:     `config: HTTP exporter endpoint must only be host and port, no scheme`,
 		},
 
 		"early error env": {


### PR DESCRIPTION
Due to how the OTEL API works we need the endpoint as only host and potentially port. No scheme and no path.

It might be worth parsing a bit better, but I expect the most common case will be to have the scheme. 

Closes #19