### PR TITLE
Allow service.name otel env variable

### DIFF
--- a/pkg/opentelemetry/config.go
+++ b/pkg/opentelemetry/config.go
@@ -266,6 +266,10 @@ func parseJSON(data json.RawMessage) (Config, error) {
 func parseEnvs(env map[string]string) (Config, error) {
 	cfg := Config{}
 
+	if serviceName, ok := env["OTEL_SERVICE_NAME"]; ok {
+		cfg.ServiceName = null.StringFrom(serviceName)
+	}
+
 	err := envconfig.Process("K6_OTEL_", &cfg, func(key string) (string, bool) {
 		v, ok := env[key]
 		return v, ok

--- a/pkg/opentelemetry/config_test.go
+++ b/pkg/opentelemetry/config_test.go
@@ -89,6 +89,24 @@ func TestConfig(t *testing.T) {
 			},
 		},
 
+		"OTEL environment variables": {
+			env: map[string]string{
+				"OTEL_SERVICE_NAME": "otel-service",
+			},
+			expectedConfig: Config{
+				ServiceName:          null.StringFrom("otel-service"),
+				ServiceVersion:       null.StringFrom(k6Const.Version),
+				ExporterType:         null.StringFrom(grpcExporterType),
+				HTTPExporterInsecure: null.NewBool(false, true),
+				HTTPExporterEndpoint: null.StringFrom("localhost:4318"),
+				HTTPExporterURLPath:  null.StringFrom("/v1/metrics"),
+				GRPCExporterInsecure: null.NewBool(false, true),
+				GRPCExporterEndpoint: null.StringFrom("localhost:4317"),
+				ExportInterval:       types.NullDurationFrom(10 * time.Second),
+				FlushInterval:        types.NullDurationFrom(1 * time.Second),
+			},
+		},
+
 		"JSON complete overwrite": {
 			jsonRaw: json.RawMessage(
 				`{` +


### PR DESCRIPTION
# Custom Environment Variables and OTEL SDK Configuration
The current implementation of `xk6-output-opentelemetry` defines several custom environment variables that, while providing fine-grained control, inadvertently prevent the use of standard OTEL SDK configuration variables. This is due to how the extension initializes the SDK with its own configuration, which takes precedence over the standard OTEL environment variables.
## Example: HTTP Exporter Configuration
Consider the following custom environment variables defined in the extension:
```golang
HTTPExporterEndpoint null.String `json:"httpExporterEndpoint" envconfig:"K6_OTEL_HTTP_EXPORTER_ENDPOINT"`
HTTPExporterURLPath null.String `json:"httpExporterURLPath" envconfig:"K6_OTEL_HTTP_EXPORTER_URL_PATH"`
```
These custom variables effectively make it impossible to use the standard OTEL variables `OTEL_EXPORTER_OTLP_ENDPOINT` or the more specific `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`. This is because:
1. The extension always provides these values to the SDK during initialization.
2. These provided values overwrite any configuration that might have been set using the standard OTEL environment variables.

## Broader Implications
This issue is not limited to the HTTP exporter configuration. Multiple custom environment variables defined at the xk6-output-opentelemetry level create similar conflicts with their standard OTEL counterparts. As a result, users cannot rely on standard OTEL configuration methods when using this extension.
## Rationale and Future Considerations
The current approach was likely adopted to provide k6-specific configurability. However, it creates a divergence from standard OTEL practices, potentially confusing users familiar with OTEL SDK configuration.

Moving forward, we should consider:
1. Gradually aligning our custom variables with standard OTEL naming conventions.
2. Implementing a fallback mechanism where standard OTEL variables are checked if custom ones are not set.
3. Providing clear documentation on which standard OTEL variables are supported and which are superseded by custom configurations.

The current PR, by adding support for `OTEL_SERVICE_NAME`, is a small step towards better alignment with standard OTEL practices. However, a more comprehensive review and refactor of the environment variable handling may be necessary in the future to fully address this issue.